### PR TITLE
Fix missing isSSRE argument in CV_loss call (Error_Landscape.R)

### DIFF
--- a/R/Error_Landscape.R
+++ b/R/Error_Landscape.R
@@ -79,7 +79,7 @@ Error_Landscape <- function(file_name, L = 10^seq(-3, 3, length.out = 100), isRe
       Kicr <- Kicrange[i]
       Kiur <- Kiurange[j]
       K <- c(Kicr, Kiur)
-      total_error[idx] <- CV_loss(K, X_setup, V0, C, IC50s, lambda)
+      total_error[idx] <- CV_loss(K, X_setup, V0, C, IC50s, lambda, isSSRE)
       S1[idx] <- Kicr
       S2[idx] <- Kiur
       idx <- idx + 1


### PR DESCRIPTION
It resolves issue #1, where the input "isSSRE" was missed in Error_Landscape